### PR TITLE
Refactor setup script logging and improve Playwright browser installation

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -37,7 +37,7 @@
     --color-popover: oklch(15.58% 0.0217 285.79);
     --color-popover-foreground: oklch(97.57% 0.0088 247.86);
     --color-primary: oklch(65.69% 0.2437 262.09);
-    --color-primary-foreground: oklch(24.26% 0.0355 285.88);
+    --color-primary-foreground: oklch(100% 0 0);
     --color-secondary: oklch(28.45% 0.0291 264.54);
     --color-secondary-foreground: oklch(97.57% 0.0088 247.86);
     --color-muted: oklch(28.45% 0.0291 264.54);

--- a/workplace/setup.sh
+++ b/workplace/setup.sh
@@ -11,7 +11,6 @@ error_handler() {
     local exit_code=$?
     local line_number=$1
     local error_message="workplace setup failed at line $line_number with exit code $exit_code"
-    echo "$error_message"
     "$SCRIPT_DIR/message.sh" "$error_message" 2>/dev/null || true
     exit $exit_code
 }
@@ -21,7 +20,7 @@ trap 'error_handler ${LINENO}' ERR
 set -e
 
 # Current script version
-VERSION="003"
+VERSION="004"
 
 # Path to the version file
 VERSION_FILE=".workplace-version"
@@ -33,54 +32,40 @@ else
     CURRENT_VERSION="000"
 fi
 
-echo "Current workplace version: $CURRENT_VERSION"
-echo "Script version: $VERSION"
-
 # Stop if workplace version is >= script version
 if [ "$CURRENT_VERSION" -ge "$VERSION" ]; then
-    echo "Workplace is up to date (version $CURRENT_VERSION). Skipping setup."
     "$SCRIPT_DIR/message.sh" "workplace setup finished" 2>/dev/null || true
     exit 0
 fi
 
-echo "Updating workplace from $CURRENT_VERSION to $VERSION..."
+"$SCRIPT_DIR/message.sh" "Updating workplace from $CURRENT_VERSION to $VERSION..." 2>/dev/null || true
 
 # Install global dependencies
-echo "Installing agent-browser globally..."
 npm install -g agent-browser
 
-echo "Installing project dependencies with pnpm..."
+# Install project dependencies
 pnpm install --frozen-lockfile
 
 # Install Playwright browsers for agent-browser.
-# Uses locally installed playwright-core version for the correct Chromium revision.
-echo "Installing Playwright browsers for agent-browser..."
+# Strategy: determine the revision required by the installed agent-browser, wipe any existing
+# (potentially broken/outdated) installation for that revision, then do a clean install
+# with --with-deps so OS-level shared libraries are also installed.
+
+BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
+
+# Find the playwright-core CLI bundled with the locally installed agent-browser
 PLAYWRIGHT_CLI=$(find node_modules/.pnpm -maxdepth 4 -name "cli.js" -path "*/playwright-core/cli.js" 2>/dev/null | head -1)
-PLAYWRIGHT_INSTALL_OK=false
-if [ -n "$PLAYWRIGHT_CLI" ]; then
-    echo "Using playwright-core CLI at: $PLAYWRIGHT_CLI"
-    if node "$PLAYWRIGHT_CLI" install chromium-headless-shell; then
-        PLAYWRIGHT_INSTALL_OK=true
-    else
-        echo "WARNING: Playwright browser download failed via local CLI, trying compatibility fallback"
-    fi
-else
-    echo "playwright-core not found in local node_modules, falling back to global playwright..."
-    if npx --yes playwright install chromium-headless-shell; then
-        PLAYWRIGHT_INSTALL_OK=true
-    else
-        echo "WARNING: Playwright browser download failed, trying compatibility fallback"
-    fi
+if [ -z "$PLAYWRIGHT_CLI" ]; then
+    # Fall back to global agent-browser's playwright-core
+    PLAYWRIGHT_CLI=$(find /opt/node*/lib/node_modules/agent-browser/node_modules/playwright-core -name "cli.js" 2>/dev/null | head -1)
 fi
 
-# If browser download failed, try to create a compatibility symlink from any cached headless shell.
-if [ "$PLAYWRIGHT_INSTALL_OK" = false ]; then
-    BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
-    # Determine required revision from the globally installed agent-browser's playwright-core
-    AGENT_PW_BROWSERS_JSON=$(find /opt/node22/lib/node_modules/agent-browser/node_modules/playwright-core -name "browsers.json" 2>/dev/null | head -1)
-    REQUIRED_REVISION=""
-    if [ -n "$AGENT_PW_BROWSERS_JSON" ] && command -v python3 &>/dev/null; then
-        REQUIRED_REVISION=$(python3 - "$AGENT_PW_BROWSERS_JSON" <<'PYEOF'
+# Determine the revision required by this playwright-core
+REQUIRED_REVISION=""
+if [ -n "$PLAYWRIGHT_CLI" ]; then
+    BROWSERS_JSON="$(dirname "$PLAYWRIGHT_CLI")/../../browsers.json"
+    if [ -f "$BROWSERS_JSON" ] && command -v python3 &>/dev/null; then
+        REQUIRED_REVISION=$(python3 - "$BROWSERS_JSON" <<'PYEOF'
 import json, sys
 with open(sys.argv[1]) as f:
     data = json.load(f)
@@ -91,37 +76,29 @@ for b in data.get('browsers', []):
 PYEOF
 )
     fi
-    if [ -n "$REQUIRED_REVISION" ]; then
-        REQUIRED_DIR="$BROWSERS_PATH/chromium_headless_shell-$REQUIRED_REVISION"
-        if [ ! -f "$REQUIRED_DIR/INSTALLATION_COMPLETE" ]; then
-            echo "Looking for a cached headless shell to use as fallback for revision $REQUIRED_REVISION..."
-            EXISTING_SHELL=$(find "$BROWSERS_PATH" -maxdepth 4 \( -name "headless_shell" -o -name "chrome-headless-shell" \) 2>/dev/null | head -1)
-            if [ -n "$EXISTING_SHELL" ]; then
-                EXISTING_SHELL_DIR="$(dirname "$EXISTING_SHELL")"
-                echo "Creating compatibility symlink from $EXISTING_SHELL_DIR"
-                mkdir -p "$REQUIRED_DIR/chrome-headless-shell-linux64"
-                for f in "$EXISTING_SHELL_DIR"/*; do
-                    ln -sf "$f" "$REQUIRED_DIR/chrome-headless-shell-linux64/$(basename "$f")" 2>/dev/null || true
-                done
-                # Ensure the expected executable name exists regardless of the source binary name
-                ln -sf "$EXISTING_SHELL" "$REQUIRED_DIR/chrome-headless-shell-linux64/chrome-headless-shell" 2>/dev/null || true
-                touch "$REQUIRED_DIR/INSTALLATION_COMPLETE"
-                touch "$REQUIRED_DIR/DEPENDENCIES_VALIDATED"
-                echo "Compatibility symlink created for chromium_headless_shell-$REQUIRED_REVISION"
-            else
-                echo "WARNING: No cached browser found. agent-browser may not work."
-            fi
-        else
-            echo "chromium_headless_shell-$REQUIRED_REVISION already available in cache"
-        fi
-    else
-        echo "WARNING: Could not determine required browser revision. agent-browser may not work."
+fi
+
+# Wipe any existing installation for the required revision so we start clean
+if [ -n "$REQUIRED_REVISION" ]; then
+    REQUIRED_DIR="$BROWSERS_PATH/chromium_headless_shell-$REQUIRED_REVISION"
+    if [ -d "$REQUIRED_DIR" ]; then
+        "$SCRIPT_DIR/message.sh" "Removing existing browser installation at $REQUIRED_DIR..." 2>/dev/null || true
+        rm -rf "$REQUIRED_DIR"
     fi
+fi
+
+# Fresh install with --with-deps to also pull in OS shared libraries
+if [ -n "$PLAYWRIGHT_CLI" ]; then
+    if node "$PLAYWRIGHT_CLI" install --with-deps chromium-headless-shell; then
+        "$SCRIPT_DIR/message.sh" "Playwright browser installed successfully" 2>/dev/null || true
+    else
+        "$SCRIPT_DIR/message.sh" "WARNING: Playwright browser install failed. agent-browser may not work." 2>/dev/null || true
+    fi
+else
+    "$SCRIPT_DIR/message.sh" "WARNING: playwright-core CLI not found. agent-browser may not work." 2>/dev/null || true
 fi
 
 # Save the new version
 echo "$VERSION" > "$VERSION_FILE"
-echo "Workplace updated to version $VERSION"
 
-# Send success message
 "$SCRIPT_DIR/message.sh" "workplace setup finished" 2>/dev/null || true


### PR DESCRIPTION
## Summary
This PR refactors the workplace setup script to centralize logging through the message.sh utility and simplifies the Playwright browser installation strategy. Additionally, it fixes the primary foreground color in the web app's CSS.

## Key Changes

### Setup Script Improvements (workplace/setup.sh)
- **Centralized Logging**: Removed direct `echo` statements and consolidated all user-facing messages through `message.sh` for consistent output handling
- **Simplified Browser Installation**: Replaced the complex fallback logic with a cleaner, more straightforward approach:
  - Removed the conditional fallback chain that attempted local CLI first, then global
  - Removed the compatibility symlink workaround for cached browsers
  - Now performs a clean installation by wiping existing installations and doing a fresh install with `--with-deps`
- **Version Bump**: Updated script version from "003" to "004"
- **Improved Comments**: Enhanced documentation of the Playwright browser installation strategy

### Web App Styling (apps/web/src/index.css)
- **Color Fix**: Changed `--color-primary-foreground` from `oklch(24.26% 0.0355 285.88)` (dark purple) to `oklch(100% 0 0)` (pure white) for better contrast and readability on primary-colored backgrounds

## Implementation Details
The new browser installation approach is more robust:
1. Locates the playwright-core CLI from the locally installed agent-browser
2. Falls back to the global agent-browser installation if needed
3. Determines the required Chromium revision from browsers.json
4. Removes any existing installation for that revision to ensure a clean state
5. Performs a fresh install with `--with-deps` to include OS-level dependencies
6. All status messages are routed through message.sh for consistent handling

https://claude.ai/code/session_014V5588G1X9vSuvS5bnbDpP